### PR TITLE
Partial revert  of "Fix #40 change payment plan labels + remove 500 template (#41)"

### DIFF
--- a/rsdockerspawner/package_data/template/500.html
+++ b/rsdockerspawner/package_data/template/500.html
@@ -1,0 +1,34 @@
+{% extends "error.html" %}
+
+{% set sirepo_msg = "" %}
+{% if exception.status_code == 500 %}
+    {% if "sirepo-community" in exception.log_message %}
+        {% set sirepo_msg = '<p>
+At this time, there are no more Sirepo Community servers available.
+</p><p>
+To get guaranteed access to Sirepo Jupyter, please upgrade
+to <a href="/plans">Sirepo Professional</a>.
+</p><p>
+If you have any questions about the plans,
+please email <a href="mailto:support@sirepo.com?subject=Upgrade+Jupyter">support@sirepo.com</a>.
+</p>' %}
+    {% elif "sirepo-unverified" in exception.log_message %}
+        {% set sirepo_msg = '<p>
+Thank you for registering to use Sirepo!
+</p><p>
+First time JupyterHub users must be verified.
+</p><p>
+If you do not hear from the Sirepo support team within one business day,
+please email <a href="mailto:support@sirepo.com?subject=Help+with+Verification">support@sirepo.com</a>
+</p><p>
+In the mean time, please feel free to use any of <a href="/">the other Sirepo apps</a>!
+</p>' %}
+    {% endif %}
+{% endif %}
+{% if sirepo_msg %}
+    {% block error_detail %}
+        {# turns off the 500 error message #}
+        <style>.error h1 { display: none; }</style>
+        <div style="text-align: left; font-size: 150%">{{ sirepo_msg | safe }}</div>
+    {% endblock %}
+{% endif %}


### PR DESCRIPTION
Brought back 500.html because it is used when a user wants to launch a server but there are no more slots left in the pool. Corrected basic/premium language in it.